### PR TITLE
Add simple support for emissions in kgCO2e

### DIFF
--- a/cmd/infracost/comment.go
+++ b/cmd/infracost/comment.go
@@ -91,6 +91,7 @@ func buildCommentBody(cmd *cobra.Command, ctx *config.RunContext, paths []string
 		NoColor:           ctx.Config.NoColor,
 		ShowSkipped:       true,
 		PolicyChecks:      policyChecks,
+		Fields:            ctx.Config.Fields,
 	}
 
 	b, err := output.ToMarkdown(combined, opts, mdOpts)

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -136,7 +136,7 @@ func (c *PricingAPIClient) buildQuery(product *schema.ProductFilter, price *sche
 				emissionHash
 				%s
 			}
-		`, "CO2e")
+		`, "emissions")
 	}
 
 	query := fmt.Sprintf(`

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -133,10 +133,14 @@ func (c *PricingAPIClient) buildQuery(product *schema.ProductFilter, price *sche
 				prices(filter: $priceFilter) {
 					priceHash
 					%s
+				},
+				emissions(filter: {}){
+					emissionHash
+					%s
 				}
 			}
 		}
-	`, c.Currency)
+	`, c.Currency, "CO2e")
 
 	return GraphQLQuery{query, v}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,7 +130,7 @@ func DefaultConfig() *Config {
 		Projects: []*Project{{}},
 
 		Format: "table",
-		Fields: []string{"monthlyQuantity", "unit", "monthlyCost"},
+		Fields: []string{"monthlyQuantity", "unit", "monthlyCost", "monthlyEmissions"},
 
 		EventsDisabled: IsTest(),
 	}

--- a/internal/output/combined.go
+++ b/internal/output/combined.go
@@ -160,10 +160,13 @@ func Combine(inputs []ReportInput) (Root, error) {
 
 	var totalHourlyCost *decimal.Decimal
 	var totalMonthlyCost *decimal.Decimal
+	var totalMonthlykgCO2e *decimal.Decimal
 	var pastTotalHourlyCost *decimal.Decimal
 	var pastTotalMonthlyCost *decimal.Decimal
+	var pastTotalMonthlykgCO2e *decimal.Decimal
 	var diffTotalHourlyCost *decimal.Decimal
 	var diffTotalMonthlyCost *decimal.Decimal
+	var diffTotalMonthlykgCO2e *decimal.Decimal
 
 	projects := make([]Project, 0)
 	summaries := make([]*Summary, 0, len(inputs))
@@ -197,6 +200,14 @@ func Combine(inputs []ReportInput) (Root, error) {
 
 			totalMonthlyCost = decimalPtr(totalMonthlyCost.Add(*input.Root.TotalMonthlyCost))
 		}
+
+		if input.Root.TotalMonthlykgCO2e != nil {
+			if totalMonthlykgCO2e == nil {
+				totalMonthlykgCO2e = decimalPtr(decimal.Zero)
+			}
+			totalMonthlykgCO2e = decimalPtr(totalMonthlykgCO2e.Add(*input.Root.TotalMonthlykgCO2e))
+		}
+
 		if input.Root.PastTotalHourlyCost != nil {
 			if pastTotalHourlyCost == nil {
 				pastTotalHourlyCost = decimalPtr(decimal.Zero)
@@ -211,6 +222,14 @@ func Combine(inputs []ReportInput) (Root, error) {
 
 			pastTotalMonthlyCost = decimalPtr(pastTotalMonthlyCost.Add(*input.Root.PastTotalMonthlyCost))
 		}
+
+		if input.Root.PastTotalMonthlykgCO2e != nil {
+			if pastTotalMonthlykgCO2e == nil {
+				pastTotalMonthlykgCO2e = decimalPtr(decimal.Zero)
+			}
+			pastTotalMonthlykgCO2e = decimalPtr(pastTotalMonthlykgCO2e.Add(*input.Root.PastTotalMonthlykgCO2e))
+		}
+
 		if input.Root.DiffTotalMonthlyCost != nil {
 			if diffTotalMonthlyCost == nil {
 				diffTotalMonthlyCost = decimalPtr(decimal.Zero)
@@ -227,6 +246,13 @@ func Combine(inputs []ReportInput) (Root, error) {
 			diffTotalHourlyCost = decimalPtr(diffTotalHourlyCost.Add(*input.Root.DiffTotalHourlyCost))
 		}
 
+		if input.Root.DiffTotalMonthlykgCO2e != nil {
+			if diffTotalMonthlykgCO2e == nil {
+				diffTotalMonthlykgCO2e = decimalPtr(decimal.Zero)
+			}
+			diffTotalMonthlykgCO2e = decimalPtr(diffTotalMonthlykgCO2e.Add(*input.Root.DiffTotalMonthlykgCO2e))
+		}
+
 		if i != 0 && metadata.VCSRepositoryURL != input.Root.Metadata.VCSRepositoryURL {
 			invalidMetadata = true
 		}
@@ -240,10 +266,13 @@ func Combine(inputs []ReportInput) (Root, error) {
 	combined.Projects = projects
 	combined.TotalHourlyCost = totalHourlyCost
 	combined.TotalMonthlyCost = totalMonthlyCost
+	combined.TotalMonthlykgCO2e = totalMonthlykgCO2e
 	combined.PastTotalHourlyCost = pastTotalHourlyCost
 	combined.PastTotalMonthlyCost = pastTotalMonthlyCost
+	combined.PastTotalMonthlykgCO2e = pastTotalMonthlykgCO2e
 	combined.DiffTotalHourlyCost = diffTotalHourlyCost
 	combined.DiffTotalMonthlyCost = diffTotalMonthlyCost
+	combined.DiffTotalMonthlykgCO2e = diffTotalMonthlykgCO2e
 	combined.TimeGenerated = time.Now().UTC()
 	combined.Summary = MergeSummaries(summaries)
 	combined.Metadata = metadata

--- a/internal/output/combined.go
+++ b/internal/output/combined.go
@@ -160,13 +160,13 @@ func Combine(inputs []ReportInput) (Root, error) {
 
 	var totalHourlyCost *decimal.Decimal
 	var totalMonthlyCost *decimal.Decimal
-	var totalMonthlykgCO2e *decimal.Decimal
+	var totalMonthlyEmissions *decimal.Decimal
 	var pastTotalHourlyCost *decimal.Decimal
 	var pastTotalMonthlyCost *decimal.Decimal
-	var pastTotalMonthlykgCO2e *decimal.Decimal
+	var pastTotalMonthlyEmissions *decimal.Decimal
 	var diffTotalHourlyCost *decimal.Decimal
 	var diffTotalMonthlyCost *decimal.Decimal
-	var diffTotalMonthlykgCO2e *decimal.Decimal
+	var diffTotalMonthlyEmissions *decimal.Decimal
 
 	projects := make([]Project, 0)
 	summaries := make([]*Summary, 0, len(inputs))
@@ -201,11 +201,11 @@ func Combine(inputs []ReportInput) (Root, error) {
 			totalMonthlyCost = decimalPtr(totalMonthlyCost.Add(*input.Root.TotalMonthlyCost))
 		}
 
-		if input.Root.TotalMonthlykgCO2e != nil {
-			if totalMonthlykgCO2e == nil {
-				totalMonthlykgCO2e = decimalPtr(decimal.Zero)
+		if input.Root.TotalMonthlyEmissions != nil {
+			if totalMonthlyEmissions == nil {
+				totalMonthlyEmissions = decimalPtr(decimal.Zero)
 			}
-			totalMonthlykgCO2e = decimalPtr(totalMonthlykgCO2e.Add(*input.Root.TotalMonthlykgCO2e))
+			totalMonthlyEmissions = decimalPtr(totalMonthlyEmissions.Add(*input.Root.TotalMonthlyEmissions))
 		}
 
 		if input.Root.PastTotalHourlyCost != nil {
@@ -223,11 +223,11 @@ func Combine(inputs []ReportInput) (Root, error) {
 			pastTotalMonthlyCost = decimalPtr(pastTotalMonthlyCost.Add(*input.Root.PastTotalMonthlyCost))
 		}
 
-		if input.Root.PastTotalMonthlykgCO2e != nil {
-			if pastTotalMonthlykgCO2e == nil {
-				pastTotalMonthlykgCO2e = decimalPtr(decimal.Zero)
+		if input.Root.PastTotalMonthlyEmissions != nil {
+			if pastTotalMonthlyEmissions == nil {
+				pastTotalMonthlyEmissions = decimalPtr(decimal.Zero)
 			}
-			pastTotalMonthlykgCO2e = decimalPtr(pastTotalMonthlykgCO2e.Add(*input.Root.PastTotalMonthlykgCO2e))
+			pastTotalMonthlyEmissions = decimalPtr(pastTotalMonthlyEmissions.Add(*input.Root.PastTotalMonthlyEmissions))
 		}
 
 		if input.Root.DiffTotalMonthlyCost != nil {
@@ -246,11 +246,11 @@ func Combine(inputs []ReportInput) (Root, error) {
 			diffTotalHourlyCost = decimalPtr(diffTotalHourlyCost.Add(*input.Root.DiffTotalHourlyCost))
 		}
 
-		if input.Root.DiffTotalMonthlykgCO2e != nil {
-			if diffTotalMonthlykgCO2e == nil {
-				diffTotalMonthlykgCO2e = decimalPtr(decimal.Zero)
+		if input.Root.DiffTotalMonthlyEmissions != nil {
+			if diffTotalMonthlyEmissions == nil {
+				diffTotalMonthlyEmissions = decimalPtr(decimal.Zero)
 			}
-			diffTotalMonthlykgCO2e = decimalPtr(diffTotalMonthlykgCO2e.Add(*input.Root.DiffTotalMonthlykgCO2e))
+			diffTotalMonthlyEmissions = decimalPtr(diffTotalMonthlyEmissions.Add(*input.Root.DiffTotalMonthlyEmissions))
 		}
 
 		if i != 0 && metadata.VCSRepositoryURL != input.Root.Metadata.VCSRepositoryURL {
@@ -266,13 +266,13 @@ func Combine(inputs []ReportInput) (Root, error) {
 	combined.Projects = projects
 	combined.TotalHourlyCost = totalHourlyCost
 	combined.TotalMonthlyCost = totalMonthlyCost
-	combined.TotalMonthlykgCO2e = totalMonthlykgCO2e
+	combined.TotalMonthlyEmissions = totalMonthlyEmissions
 	combined.PastTotalHourlyCost = pastTotalHourlyCost
 	combined.PastTotalMonthlyCost = pastTotalMonthlyCost
-	combined.PastTotalMonthlykgCO2e = pastTotalMonthlykgCO2e
+	combined.PastTotalMonthlyEmissions = pastTotalMonthlyEmissions
 	combined.DiffTotalHourlyCost = diffTotalHourlyCost
 	combined.DiffTotalMonthlyCost = diffTotalMonthlyCost
-	combined.DiffTotalMonthlykgCO2e = diffTotalMonthlykgCO2e
+	combined.DiffTotalMonthlyEmissions = diffTotalMonthlyEmissions
 	combined.TimeGenerated = time.Now().UTC()
 	combined.Summary = MergeSummaries(summaries)
 	combined.Metadata = metadata

--- a/internal/output/diff.go
+++ b/internal/output/diff.go
@@ -255,16 +255,6 @@ func costComponentToDiff(currency string, diffComponent CostComponent, oldCompon
 
 	s += fmt.Sprintf("%s %s\n", opChar(op), colorizeDiffName(diffComponent.Name))
 
-	if showEmissions {
-		if oldEmissions == nil && newEmissions == nil {
-			s += "  Monthly emissions depends on usage\n"
-		} else {
-			s += fmt.Sprintf("  %s%s\n",
-				formatEmissionsChange(diffComponent.MonthlyEmissions, "kgCO2e"),
-				ui.FaintString(formatEmissionsChangeDetails(oldEmissions, newEmissions, "kgCO2e")),
-			)
-		}
-	}
 	if oldCost == nil && newCost == nil {
 		s += "  Monthly cost depends on usage\n"
 		s += fmt.Sprintf("    %s per %s%s\n",
@@ -277,6 +267,17 @@ func costComponentToDiff(currency string, diffComponent CostComponent, oldCompon
 			formatCostChange(currency, diffComponent.MonthlyCost),
 			ui.FaintString(formatCostChangeDetails(currency, oldCost, newCost)),
 		)
+	}
+
+	if showEmissions {
+		if oldEmissions == nil && newEmissions == nil {
+			s += "  Monthly emissions depends on usage\n"
+		} else {
+			s += fmt.Sprintf("  %s%s\n",
+				formatEmissionsChange(diffComponent.MonthlyEmissions, "kgCO2e"),
+				ui.FaintString(formatEmissionsChangeDetails(oldEmissions, newEmissions, "kgCO2e")),
+			)
+		}
 	}
 
 	return s

--- a/internal/output/diff.go
+++ b/internal/output/diff.go
@@ -185,7 +185,7 @@ func resourceToDiff(currency string, diffResource Resource, oldResource *Resourc
 		}
 		if showEmissions {
 			if oldEmissions == nil && newEmissions == nil {
-				s += "  Monthly emissions depends on usage\n"
+				s += "  Monthly emissions depend on usage\n"
 			} else {
 				s += fmt.Sprintf("  %s%s\n",
 					formatEmissionsChange(diffResource.MonthlyEmissions, "kgCO2e"),
@@ -271,7 +271,7 @@ func costComponentToDiff(currency string, diffComponent CostComponent, oldCompon
 
 	if showEmissions {
 		if oldEmissions == nil && newEmissions == nil {
-			s += "  Monthly emissions depends on usage\n"
+			s += "  Monthly emissions depend on usage\n"
 		} else {
 			s += fmt.Sprintf("  %s%s\n",
 				formatEmissionsChange(diffComponent.MonthlyEmissions, "kgCO2e"),

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -36,6 +36,12 @@ func formatCost2DP(currency string, d *decimal.Decimal) string {
 	}
 	return formatRoundedDecimalCurrency(currency, *d)
 }
+func formatEmissions(emissions *decimal.Decimal, unit string) string {
+	if emissions == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%s %s", fmt.Sprint(emissions), unit)
+}
 
 func formatPrice(currency string, d decimal.Decimal) string {
 	if d.LessThan(decimal.NewFromFloat(0.1)) {

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -40,7 +40,12 @@ func formatEmissions(emissions *decimal.Decimal, unit string) string {
 	if emissions == nil {
 		return "-"
 	}
-	return fmt.Sprintf("%s %s", fmt.Sprint(emissions), unit)
+	return fmt.Sprintf("%s %s", fmt.Sprint(formatRoundedDecimalEmissions(*emissions)), unit)
+}
+
+func formatRoundedDecimalEmissions(d decimal.Decimal) *decimal.Decimal {
+	d = d.Round(1)
+	return &d
 }
 
 func formatPrice(currency string, d decimal.Decimal) string {
@@ -71,6 +76,10 @@ func formatWholeDecimalCurrency(currency string, d decimal.Decimal) string {
 	scaledInt := decimalToScaledInt(d, 0, 0)
 	formatter.Fraction = scaledInt.FractionLength
 	return formatter.Format(scaledInt.Number)
+}
+
+func formatWholeDecimalEmissions(d decimal.Decimal) string {
+	return fmt.Sprintf("%s", fmt.Sprint(d))
 }
 
 type scaledInt64 struct {

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -119,6 +119,10 @@ func formatTitleWithCurrency(title, currency string) string {
 	return fmt.Sprintf("%s (%s)", title, currency)
 }
 
+func formatTitleEmissions(title string) string {
+	return fmt.Sprintf("%s", title)
+}
+
 func truncateMiddle(s string, maxLen int, fill string) string {
 	r := []rune(s)
 

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -36,6 +36,7 @@ func formatCost2DP(currency string, d *decimal.Decimal) string {
 	}
 	return formatRoundedDecimalCurrency(currency, *d)
 }
+
 func formatEmissions(emissions *decimal.Decimal, unit string) string {
 	if emissions == nil {
 		return "-"

--- a/internal/output/html.go
+++ b/internal/output/html.go
@@ -44,6 +44,13 @@ func ToHTML(out Root, opts Options) ([]byte, error) {
 		"filterZeroValResources":  filterZeroValResources,
 		"formatCost2DP":           func(d *decimal.Decimal) string { return formatCost2DP(out.Currency, d) },
 		"formatPrice":             func(d decimal.Decimal) string { return formatPrice(out.Currency, d) },
+		"formatEmissions":         func(d *decimal.Decimal) string { return formatEmissions(d, "kgCO2e") },
+		"customLength": func(s []string) int {
+			if contains(s, "monthlyEmissions") {
+				return len(s) - 1
+			}
+			return len(s)
+		},
 		"formatTitleWithCurrency": func(title string) string { return formatTitleWithCurrency(title, out.Currency) },
 		"formatQuantity":          formatQuantity,
 		"projectLabel": func(p Project) string {

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -191,9 +191,6 @@ func ToMarkdown(out Root, opts Options, markdownOpts MarkdownOptions) ([]byte, e
 			return formatMarkdownEmissionsChange(pastCost, cost)
 		},
 		"formatEmissionsChangeSentence": formatEmissionsChangeSentence,
-		"formatFields": func(fields []string) string {
-			return strings.Join(fields, ", ")
-		},
 		"metadataHeaders": func() []string {
 			headers := []string{}
 			if hasModulePath {

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -167,8 +167,8 @@ func ToMarkdown(out Root, opts Options, markdownOpts MarkdownOptions) ([]byte, e
 	tmpl := template.New("base")
 	tmpl.Funcs(sprig.TxtFuncMap())
 	tmpl.Funcs(template.FuncMap{
-		"emissionsNotZero": func(pastEmissions, emissions *decimal.Decimal) bool {
-			return pastEmissions != nil && !pastEmissions.IsZero() || emissions != nil && !emissions.IsZero()
+		"showEmissions": func() bool {
+			return contains(opts.Fields, "monthlyEmissions")
 		},
 		"formatCost": func(d *decimal.Decimal) string {
 			if d == nil || d.IsZero() {

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"sort"
+	"strings"
 	"text/template"
 	"unicode/utf8"
 
@@ -47,6 +48,29 @@ func formatMarkdownCostChange(currency string, pastCost, cost *decimal.Decimal, 
 	return plusMinus + formatCost(currency, cost) + percentChange
 }
 
+func formatMarkdownEmissionsChange(pastEmissions, emissions *decimal.Decimal) string {
+	if pastEmissions != nil && pastEmissions.Equals(*emissions) {
+		return formatWholeDecimalEmissions(decimal.Zero)
+	}
+
+	percentChange := formatPercentChange(pastEmissions, emissions)
+	if len(percentChange) > 0 {
+		percentChange = " " + "(" + percentChange + ")"
+	}
+
+	plusMinus := "+"
+	if pastEmissions != nil {
+		d := emissions.Sub(*pastEmissions)
+		if d.LessThan(decimal.Zero) {
+			plusMinus = ""
+		}
+
+		return plusMinus + formatEmissions(&d, "kgCO2e") + percentChange
+	}
+
+	return plusMinus + formatEmissions(emissions, "kgCO2e") + percentChange
+}
+
 func formatCostChangeSentence(currency string, pastCost, cost *decimal.Decimal, useEmoji bool) string {
 	up := "📈"
 	down := "📉"
@@ -64,6 +88,25 @@ func formatCostChangeSentence(currency string, pastCost, cost *decimal.Decimal, 
 		}
 	}
 	return "monthly cost will increase by " + formatMarkdownCostChange(currency, pastCost, cost, true) + " " + up
+}
+
+func formatEmissionsChangeSentence(pastEmissions, emissions *decimal.Decimal, useEmoji bool) string {
+	up := "📈"
+	down := "📉"
+
+	if !useEmoji {
+		up = "↑"
+		down = "↓"
+	}
+
+	if pastEmissions != nil {
+		if pastEmissions.Equals(*emissions) {
+			return "emissions will not change"
+		} else if pastEmissions.GreaterThan(*emissions) {
+			return "emissions will decrease by " + formatMarkdownEmissionsChange(pastEmissions, emissions) + " " + down
+		}
+	}
+	return "emissions will increase by " + formatMarkdownEmissionsChange(pastEmissions, emissions) + " " + up
 }
 
 func calculateMetadataToDisplay(projects []Project) (hasModulePath bool, hasWorkspace bool) {
@@ -124,6 +167,9 @@ func ToMarkdown(out Root, opts Options, markdownOpts MarkdownOptions) ([]byte, e
 	tmpl := template.New("base")
 	tmpl.Funcs(sprig.TxtFuncMap())
 	tmpl.Funcs(template.FuncMap{
+		"emissionsNotZero": func(pastEmissions, emissions *decimal.Decimal) bool {
+			return pastEmissions != nil && !pastEmissions.IsZero() || emissions != nil && !emissions.IsZero()
+		},
 		"formatCost": func(d *decimal.Decimal) string {
 			if d == nil || d.IsZero() {
 				return formatWholeDecimalCurrency(out.Currency, decimal.Zero)
@@ -139,6 +185,14 @@ func ToMarkdown(out Root, opts Options, markdownOpts MarkdownOptions) ([]byte, e
 				return false
 			}
 			return true
+		},
+		"formatEmissions": func(d *decimal.Decimal) string { return formatEmissions(d, "kgCO2e") },
+		"formatEmissionsChange": func(pastCost, cost *decimal.Decimal) string {
+			return formatMarkdownEmissionsChange(pastCost, cost)
+		},
+		"formatEmissionsChangeSentence": formatEmissionsChangeSentence,
+		"formatFields": func(fields []string) string {
+			return strings.Join(fields, ", ")
 		},
 		"metadataHeaders": func() []string {
 			headers := []string{}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -106,6 +106,7 @@ func convertCostComponents(outComponents []CostComponent) []*schema.CostComponen
 			MonthlyQuantity:  c.MonthlyQuantity,
 		}
 		sc.SetPrice(c.Price)
+		sc.SetEmission(c.Emission)
 
 		components[i] = sc
 	}
@@ -180,6 +181,7 @@ type CostComponent struct {
 	HourlyQuantity   *decimal.Decimal `json:"hourlyQuantity"`
 	MonthlyQuantity  *decimal.Decimal `json:"monthlyQuantity"`
 	Price            decimal.Decimal  `json:"price"`
+	Emission         decimal.Decimal  `json:"emission"`
 	HourlyCost       *decimal.Decimal `json:"hourlyCost"`
 	MonthlyCost      *decimal.Decimal `json:"monthlyCost"`
 	MonthlyEmissions *decimal.Decimal `json:"monthlyEmissions"`

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -16,7 +16,7 @@ import (
 	"github.com/infracost/infracost/internal/usage"
 )
 
-var outputVersion = "0.3"
+var outputVersion = "0.2"
 
 type Root struct {
 	Version                   string           `json:"version"`
@@ -301,13 +301,13 @@ func outputBreakdown(resources []*schema.Resource) *Breakdown {
 	sortResources(arr, "")
 
 	totalMonthlyCost, totalHourlyCost := calculateTotalCosts(arr)
-	totalMonthlykgCO2e := calculateTotalkgCO2e(arr)
+	totalMonthlyEmissions := calculateTotalEmissions(arr)
 
 	return &Breakdown{
 		Resources:             arr,
 		TotalHourlyCost:       totalMonthlyCost,
 		TotalMonthlyCost:      totalHourlyCost,
-		TotalMonthlyEmissions: totalMonthlykgCO2e,
+		TotalMonthlyEmissions: totalMonthlyEmissions,
 	}
 }
 
@@ -454,8 +454,8 @@ func ToOutputFormat(projects []*schema.Project) (Root, error) {
 					if diffTotalMonthlyEmissions == nil {
 						diffTotalMonthlyEmissions = decimalPtr(decimal.Zero)
 					}
+					diffTotalMonthlyEmissions = decimalPtr(diffTotalMonthlyEmissions.Add(*diff.TotalMonthlyEmissions))
 				}
-				diffTotalMonthlyEmissions = decimalPtr(diffTotalMonthlyEmissions.Add(*diff.TotalMonthlyEmissions))
 			}
 		}
 
@@ -796,20 +796,20 @@ func calculateTotalCosts(resources []Resource) (*decimal.Decimal, *decimal.Decim
 	return totalHourlyCost, totalMonthlyCost
 }
 
-func calculateTotalkgCO2e(resources []Resource) *decimal.Decimal {
-	totalkgCO2e := decimalPtr(decimal.Zero)
+func calculateTotalEmissions(resources []Resource) *decimal.Decimal {
+	totalEmissions := decimalPtr(decimal.Zero)
 
 	for _, r := range resources {
 		if r.MonthlyEmissions != nil {
-			if totalkgCO2e == nil {
-				totalkgCO2e = decimalPtr(decimal.Zero)
+			if totalEmissions == nil {
+				totalEmissions = decimalPtr(decimal.Zero)
 			}
 
-			totalkgCO2e = decimalPtr(totalkgCO2e.Add(*r.MonthlyEmissions))
+			totalEmissions = decimalPtr(totalEmissions.Add(*r.MonthlyEmissions))
 		}
 	}
 
-	return totalkgCO2e
+	return totalEmissions
 }
 
 func sortResources(resources []Resource, groupKey string) {

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -80,7 +80,7 @@ func ToTable(out Root, opts Options) ([]byte, error) {
 	if contains(opts.Fields, "monthlyEmissions") {
 		emissionsShift = len("Monthly Emissions") + 2
 		priceShift -= emissionsShift
-		totalEmissions = fmt.Sprintf("%*s", emissionsShift, formatEmissions(out.TotalMonthlykgCO2e, "kgCO2e"))
+		totalEmissions = fmt.Sprintf("%*s", emissionsShift, formatEmissions(out.TotalMonthlyEmissions, "kgCO2e"))
 	}
 
 	s += fmt.Sprintf("%s%s%s",

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -76,15 +76,17 @@ func ToTable(out Root, opts Options) ([]byte, error) {
 	overallTitle := formatTitleWithCurrency(" OVERALL TOTAL", out.Currency)
 	emissionsShift := 0
 	priceShift := tableLen - (len(overallTitle) + 1)
+	totalEmissions := ""
 	if contains(opts.Fields, "monthlyEmissions") {
 		emissionsShift = len("Monthly Emissions") + 2
 		priceShift -= emissionsShift
+		totalEmissions = fmt.Sprintf("%*s", emissionsShift, formatEmissions(out.TotalMonthlykgCO2e, "kgCO2e"))
 	}
 
 	s += fmt.Sprintf("%s%s%s",
 		ui.BoldString(overallTitle),
 		fmt.Sprintf("%*s", priceShift, totalOut),
-		fmt.Sprintf("%*s", emissionsShift, formatEmissions(out.TotalMonthlykgCO2e, "kgCO2e")), // pad based on the last line length
+		totalEmissions, // pad based on the last line length
 	)
 
 	summaryMsg := out.summaryMessage(opts.ShowSkipped)

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -74,9 +74,17 @@ func ToTable(out Root, opts Options) ([]byte, error) {
 	totalOut := formatCost2DP(out.Currency, out.TotalMonthlyCost)
 
 	overallTitle := formatTitleWithCurrency(" OVERALL TOTAL", out.Currency)
-	s += fmt.Sprintf("%s%s",
+	emissionsShift := 0
+	priceShift := tableLen - (len(overallTitle) + 1)
+	if contains(opts.Fields, "monthlyEmissions") {
+		emissionsShift = len("Monthly Emissions") + 2
+		priceShift -= emissionsShift
+	}
+
+	s += fmt.Sprintf("%s%s%s",
 		ui.BoldString(overallTitle),
-		fmt.Sprintf("%*s ", tableLen-(len(overallTitle)+1), totalOut), // pad based on the last line length
+		fmt.Sprintf("%*s", priceShift, totalOut),
+		fmt.Sprintf("%*s", emissionsShift, formatEmissions(out.TotalMonthlykgCO2e, "kgCO2e")), // pad based on the last line length
 	)
 
 	summaryMsg := out.summaryMessage(opts.ShowSkipped)
@@ -149,6 +157,15 @@ func tableForBreakdown(currency string, breakdown Breakdown, fields []string, in
 	}
 	if contains(fields, "monthlyCost") {
 		headers = append(headers, ui.UnderlineString(formatTitleWithCurrency("Monthly Cost", currency)))
+		columns = append(columns, table.ColumnConfig{
+			Number:      i,
+			Align:       text.AlignRight,
+			AlignHeader: text.AlignRight,
+		})
+		i++
+	}
+	if contains(fields, "monthlyEmissions") {
+		headers = append(headers, ui.UnderlineString("Monthly Emissions"))
 		columns = append(columns, table.ColumnConfig{
 			Number:      i,
 			Align:       text.AlignRight,
@@ -256,6 +273,9 @@ func buildCostComponentRows(t table.Writer, currency string, costComponents []Co
 			}
 			if contains(fields, "monthlyCost") {
 				tableRow = append(tableRow, formatCost2DP(currency, c.MonthlyCost))
+			}
+			if contains(fields, "monthlyEmissions") {
+				tableRow = append(tableRow, formatEmissions(c.MonthlyEmissions, "kgCO2e"))
 			}
 
 			t.AppendRow(tableRow)

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -202,10 +202,16 @@ func tableForBreakdown(currency string, breakdown Breakdown, fields []string, in
 		var totalCostRow table.Row
 		totalCostRow = append(totalCostRow, ui.BoldString(formatTitleWithCurrency("Project total", currency)))
 		numOfFields := i - 3
+		if contains(fields, "monthlyEmissions") {
+			numOfFields -= 1
+		}
 		for q := 0; q < numOfFields; q++ {
 			totalCostRow = append(totalCostRow, "")
 		}
 		totalCostRow = append(totalCostRow, formatCost2DP(currency, breakdown.TotalMonthlyCost))
+		if contains(fields, "monthlyEmissions") {
+			totalCostRow = append(totalCostRow, ui.BoldString(formatEmissions(breakdown.TotalMonthlyEmissions, "kgCO2e")))
+		}
 		t.AppendRow(totalCostRow)
 	}
 

--- a/internal/output/templates.go
+++ b/internal/output/templates.go
@@ -51,7 +51,7 @@ td.name {
   max-width: 32rem;
 }
 
-td.monthly-quantity, td.price, td.hourly-cost, td.monthly-cost td.monthly-emissions {
+td.monthly-quantity, td.price, td.hourly-cost, td.monthly-cost, td.monthly-emissions {
   text-align: right;
 }
 

--- a/internal/output/templates.go
+++ b/internal/output/templates.go
@@ -319,7 +319,7 @@ var CommentMarkdownWithHTMLTemplate = `
       <td align="right">{{ formatCost .PastCost }}</td>
       <td align="right">{{ formatCost .Cost }}</td>
       <td>{{ formatCostChange .PastCost .Cost }}</td>
-      {{- if emissionsNotZero .PastEmissions .Emissions }}
+      {{- if showEmissions }}
       <td align="right">{{ formatEmissions .PastEmissions }}</td>
       <td align="right">{{ formatEmissions .Emissions }}</td>
       <td>{{ formatEmissionsChange .PastEmissions .Emissions }}</td>
@@ -327,7 +327,7 @@ var CommentMarkdownWithHTMLTemplate = `
     </tr>
 {{- end}}
 💰 Infracost cost estimate: **{{ formatCostChangeSentence .Root.Currency .Root.PastTotalMonthlyCost .Root.TotalMonthlyCost true }}**
-{{- if emissionsNotZero .Root.PastTotalMonthlyEmissions .Root.TotalMonthlyEmissions }}
+{{- if showEmissions }}
 🏭 Carbon emissions estimate: **{{ formatEmissionsChangeSentence .Root.PastTotalMonthlyEmissions .Root.TotalMonthlyEmissions true }}**
 {{- end }}
 <table>
@@ -339,7 +339,7 @@ var CommentMarkdownWithHTMLTemplate = `
     <td>Previous Cost</td>
     <td>New Cost</td>
     <td>Diff Cost</td>
-    {{- if emissionsNotZero .Root.PastTotalMonthlyEmissions .Root.TotalMonthlyEmissions }}
+    {{- if showEmissions }}
     <td>Previous Emissions</td>
     <td>New Emissions</td>
     <td>Diff Emissions</td>

--- a/internal/output/templates.go
+++ b/internal/output/templates.go
@@ -319,18 +319,31 @@ var CommentMarkdownWithHTMLTemplate = `
       <td align="right">{{ formatCost .PastCost }}</td>
       <td align="right">{{ formatCost .Cost }}</td>
       <td>{{ formatCostChange .PastCost .Cost }}</td>
+      {{- if emissionsNotZero .PastEmissions .Emissions }}
+      <td align="right">{{ formatEmissions .PastEmissions }}</td>
+      <td align="right">{{ formatEmissions .Emissions }}</td>
+      <td>{{ formatEmissionsChange .PastEmissions .Emissions }}</td>
+      {{- end }}
     </tr>
 {{- end}}
-💰 Infracost estimate: **{{ formatCostChangeSentence .Root.Currency .Root.PastTotalMonthlyCost .Root.TotalMonthlyCost true }}**
+💰 Infracost cost estimate: **{{ formatCostChangeSentence .Root.Currency .Root.PastTotalMonthlyCost .Root.TotalMonthlyCost true }}**
+{{- if emissionsNotZero .Root.PastTotalMonthlyEmissions .Root.TotalMonthlyEmissions }}
+🏭 Carbon emissions estimate: **{{ formatEmissionsChangeSentence .Root.PastTotalMonthlyEmissions .Root.TotalMonthlyEmissions true }}**
+{{- end }}
 <table>
   <thead>
     <td>Project</td>
 {{- range metadataHeaders }}
     <td>{{ . }}</td>
 {{- end }}
-    <td>Previous</td>
-    <td>New</td>
-    <td>Diff</td>
+    <td>Previous Cost</td>
+    <td>New Cost</td>
+    <td>Diff Cost</td>
+    {{- if emissionsNotZero .Root.PastTotalMonthlyEmissions .Root.TotalMonthlyEmissions }}
+    <td>Previous Emissions</td>
+    <td>New Emissions</td>
+    <td>Diff Emissions</td>
+    {{- end }}
   </thead>
 {{- if gt (len .Root.Projects) 1  }}
   <tbody>
@@ -353,7 +366,7 @@ var CommentMarkdownWithHTMLTemplate = `
 {{- else }}
   <tbody>
   {{- range .Root.Projects }}
-    {{- template "summaryRow" dict "Name" .Name "MetadataFields" (. | metadataFields) "PastCost" .PastBreakdown.TotalMonthlyCost "Cost" .Breakdown.TotalMonthlyCost  }}
+    {{- template "summaryRow" dict "Name" .Name "MetadataFields" (. | metadataFields) "PastCost" .PastBreakdown.TotalMonthlyCost "Cost" .Breakdown.TotalMonthlyCost "PastEmissions" .PastBreakdown.TotalMonthlyEmissions "Emissions" .Breakdown.TotalMonthlyEmissions }}
   {{- end }}
   </tbody>
 </table>
@@ -418,10 +431,10 @@ var CommentMarkdownTemplate = `
 {{- if gt (len .Root.Projects) 1  }}
   {{- range .Root.Projects }}
     {{- if hasDiff . }}
-      {{- template "summaryRow" dict "Name" .Name "MetadataFields" (. | metadataFields) "PastCost" .PastBreakdown.TotalMonthlyCost "Cost" .Breakdown.TotalMonthlyCost  }}
+      {{- template "summaryRow" dict "Name" .Name "MetadataFields" (. | metadataFields) "PastCost" .PastBreakdown.TotalMonthlyCost "Cost" .Breakdown.TotalMonthlyCost "PastEmissions" .PastBreakdown.TotalMonthlyEmissions "Emissions" .Breakdown.TotalMonthlyEmissions }}
     {{- end }}
   {{- end }}
-  {{- template "totalRow" dict "Name" "All projects" "PastCost" .Root.PastTotalMonthlyCost "Cost" .Root.TotalMonthlyCost  }}
+  {{- template "totalRow" dict "Name" "All projects" "PastCost" .Root.PastTotalMonthlyCost "Cost" .Root.TotalMonthlyCost "PastEmissions" .Root.PastTotalMonthlyEmissions "Emissions" .Root.TotalMonthlyEmissions }}
 
   {{- if eq .SkippedProjectCount 1 }}
 
@@ -432,7 +445,7 @@ var CommentMarkdownTemplate = `
   {{- end }}
 {{- else }}
   {{- range .Root.Projects }}
-    {{- template "summaryRow" dict "Name" .Name "MetadataFields" (. | metadataFields) "PastCost" .PastBreakdown.TotalMonthlyCost "Cost" .Breakdown.TotalMonthlyCost  }}
+    {{- template "summaryRow" dict "Name" .Name "MetadataFields" (. | metadataFields) "PastCost" .PastBreakdown.TotalMonthlyCost "Cost" .Breakdown.TotalMonthlyCost "PastEmissions" .PastBreakdown.TotalMonthlyEmissions "Emissions" .Breakdown.TotalMonthlyEmissions }}
   {{- end }}
 {{- end }}
 

--- a/internal/output/templates.go
+++ b/internal/output/templates.go
@@ -51,7 +51,7 @@ td.name {
   max-width: 32rem;
 }
 
-td.monthly-quantity, td.price, td.hourly-cost, td.monthly-cost {
+td.monthly-quantity, td.price, td.hourly-cost, td.monthly-cost td.monthly-emissions {
   text-align: right;
 }
 
@@ -136,6 +136,9 @@ iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAMAAABlApw1AAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7O
   {{if contains .Fields "monthlyCost"}}
     <td class="monthly-cost"></td>
   {{end}}
+  {{if contains .Fields "monthlyEmissions"}}
+    <td class="monthly-emissions"></td>
+  {{end}}
 {{end}}
 
 {{define "resourceRows"}}
@@ -198,6 +201,9 @@ iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAMAAABlApw1AAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7O
       {{if contains .Fields "monthlyCost"}}
         <td class="monthly-cost">{{.CostComponent.MonthlyCost | formatCost2DP}}</td>
       {{end}}
+      {{if contains .Fields "monthlyEmissions"}}
+        <td class="monthly-emissions">{{.CostComponent.MonthlyEmissions | formatEmissions}}</td>
+      {{end}}
     {{else}}
       <td colspan="{{len .Fields}}" class="usage-cost">Cost depends on usage: {{.CostComponent.Price | formatPrice}} per {{.CostComponent.Unit}}</td>
     {{end}}
@@ -221,6 +227,9 @@ iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAMAAABlApw1AAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7O
   {{if contains .Fields "monthlyCost"}}
     <td class="monthly-cost">{{ "Monthly Cost" | formatTitleWithCurrency }}</td>
   {{end}}
+  {{if contains .Fields "monthlyEmissions"}}
+    <td class="monthly-emissions">{{ "Monthly Emissions" | formatTitleWithCurrency }}</td>
+  {{end}}
 {{end}}
 
 {{define "projectBlock"}}
@@ -241,8 +250,11 @@ iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAMAAABlApw1AAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7O
         {{template "resourceRows" dict "Resource" . "Fields" $fields "Indent" 0}}
       {{end}}
       <tr class="total">
-        <td class="name" colspan="{{len .Options.Fields}}">Project total</td>
+        <td class="name" colspan="{{customLength .Options.Fields}}">Project total {{customLength .Options.Fields}}</td>
         <td class="monthly-cost">{{.Project.Breakdown.TotalMonthlyCost | formatCost2DP}}</td>
+        {{if contains .Options.Fields "monthlyEmissions"}}
+          <td class="monthly-emissions">{{.Project.Breakdown.TotalMonthlyEmissions | formatEmissions}}</td>
+        {{end}}
       </tr>
     </tbody>
   </table>
@@ -282,8 +294,11 @@ iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAMAAABlApw1AAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7O
     <table class="overall-total">
       <tbody>
         <tr class="total">
-          <td class="name" colspan="{{len .Options.Fields}}">{{ "Overall total" | formatTitleWithCurrency }}</td>
+          <td class="name" colspan="{{customLength .Options.Fields}}">{{ "Overall total" | formatTitleWithCurrency }}</td>
           <td class="monthly-cost">{{.Root.TotalMonthlyCost | formatCost2DP}}</td>
+          {{if contains .Options.Fields "monthlyEmissions"}}
+          <td class="monthly-emissions">{{.Root.TotalMonthlyEmissions | formatEmissions}}</td>
+          {{end}}
         </tr>
       </tbody>
     </table>

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -214,9 +214,9 @@ func setComponentEmissions(ctx *config.RunContext, currency string, r *schema.Re
 	}
 
 	var err error
-	p, err = decimal.NewFromString(emissions[0].Get("CO2e").String())
+	p, err = decimal.NewFromString(emissions[0].Get("emissions").String())
 	if err != nil {
-		log.Warnf("Error converting emissions to '%v' (using 0.00)  '%v': %s", "CO2e", emissions[0].Get("CO2e").String(), err.Error())
+		log.Warnf("Error converting emissions to '%v' (using 0.00)  '%v': %s", "emissions", emissions[0].Get("emissions").String(), err.Error())
 		setResourceWarningEvent(ctx, r, "Error converting emission")
 		c.SetEmission(decimal.Zero)
 		return

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -78,7 +78,9 @@ func GetPrices(ctx *config.RunContext, c *apiclient.PricingAPIClient, r *schema.
 
 	for _, r := range results {
 		setCostComponentPrice(ctx, c.Currency, r.Resource, r.CostComponent, r.Result)
-		setComponentEmissions(ctx, c.Currency, r.Resource, r.CostComponent, r.Result)
+		if c.EmissionsEnabled {
+			setComponentEmissions(ctx, c.Currency, r.Resource, r.CostComponent, r.Result)
+		}
 	}
 
 	return nil

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -194,15 +194,9 @@ func setComponentEmissions(ctx *config.RunContext, currency string, r *schema.Re
 	}
 
 	if len(productsWithEmissions) == 0 {
-		if c.IgnoreIfMissingPrice {
-			log.Debugf("No emissions found for %s %s, ignoring since IgnoreIfMissingPrice is set.", r.Name, c.Name)
-			r.RemoveCostComponent(c)
-			return
-		}
-
 		log.Warnf("No emissions found for %s %s, using 0.00", r.Name, c.Name)
 		setResourceWarningEvent(ctx, r, "No prices found")
-		c.SetPrice(decimal.Zero)
+		c.SetEmission(decimal.Zero)
 		return
 	}
 
@@ -222,7 +216,7 @@ func setComponentEmissions(ctx *config.RunContext, currency string, r *schema.Re
 	if err != nil {
 		log.Warnf("Error converting emissions to '%v' (using 0.00)  '%v': %s", "CO2e", emissions[0].Get("CO2e").String(), err.Error())
 		setResourceWarningEvent(ctx, r, "Error converting emission")
-		c.SetPrice(decimal.Zero)
+		c.SetEmission(decimal.Zero)
 		return
 	}
 

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -185,9 +185,9 @@ func setComponentEmissions(ctx *config.RunContext, currency string, r *schema.Re
 
 	// Some resources may have identical records in CPAPI for the same product
 	// filters, several products are always returned and they can only be
-	// distinguished by their prices. However if we pick the first product it may not
-	// have the price due to price filter and the lookup fails. Filtering the
-	// products with prices helps to solve that.
+	// distinguished by their emissions. However if we pick the first product it may not
+	// have the emissions due to emissions filter and the lookup fails. Filtering the
+	// products with emissions helps to solve that.
 	productsWithEmissions := []gjson.Result{}
 	for _, product := range products {
 		if len(product.Get("emissions").Array()) > 0 {
@@ -197,7 +197,7 @@ func setComponentEmissions(ctx *config.RunContext, currency string, r *schema.Re
 
 	if len(productsWithEmissions) == 0 {
 		log.Warnf("No emissions found for %s %s, using 0.00", r.Name, c.Name)
-		setResourceWarningEvent(ctx, r, "No prices found")
+		setResourceWarningEvent(ctx, r, "No emissions found")
 		c.SetEmission(decimal.Zero)
 		return
 	}
@@ -209,7 +209,7 @@ func setComponentEmissions(ctx *config.RunContext, currency string, r *schema.Re
 
 	emissions := productsWithEmissions[0].Get("emissions").Array()
 	if len(emissions) > 1 {
-		log.Warnf("Multiple emissions found for %s %s, using the first price", r.Name, c.Name)
+		log.Warnf("Multiple emissions found for %s %s, using the first emissions value", r.Name, c.Name)
 		setResourceWarningEvent(ctx, r, "Multiple emissions found")
 	}
 

--- a/internal/schema/cost_component.go
+++ b/internal/schema/cost_component.go
@@ -17,8 +17,11 @@ type CostComponent struct {
 	price                decimal.Decimal
 	customPrice          *decimal.Decimal
 	priceHash            string
+	emission             decimal.Decimal
+	emissionHash         string
 	HourlyCost           *decimal.Decimal
 	MonthlyCost          *decimal.Decimal
+	MonthlyEmissions     *decimal.Decimal
 }
 
 func (c *CostComponent) CalculateCosts() {
@@ -29,6 +32,12 @@ func (c *CostComponent) CalculateCosts() {
 	if c.MonthlyQuantity != nil {
 		discountMul := decimal.NewFromFloat(1.0 - c.MonthlyDiscountPerc)
 		c.MonthlyCost = decimalPtr(c.price.Mul(*c.MonthlyQuantity).Mul(discountMul))
+	}
+}
+
+func (c *CostComponent) CalculateEmittedCO2() {
+	if c.MonthlyQuantity != nil {
+		c.MonthlyEmissions = decimalPtr(c.emission.Mul(*c.MonthlyQuantity))
 	}
 }
 
@@ -54,6 +63,22 @@ func (c *CostComponent) SetPriceHash(priceHash string) {
 
 func (c *CostComponent) PriceHash() string {
 	return c.priceHash
+}
+
+func (c *CostComponent) SetEmission(emission decimal.Decimal) {
+	c.emission = emission
+}
+
+func (c *CostComponent) Emission() decimal.Decimal {
+	return c.emission
+}
+
+func (c *CostComponent) SetEmissionHash(emissionHash string) {
+	c.emissionHash = emissionHash
+}
+
+func (c *CostComponent) EmissionHash() string {
+	return c.emissionHash
 }
 
 func (c *CostComponent) SetCustomPrice(price *decimal.Decimal) {

--- a/internal/schema/diff.go
+++ b/internal/schema/diff.go
@@ -84,8 +84,9 @@ func diffResourcesByKey(resourceKey string, pastResMap, currentResMap map[string
 		ResourceType: baseResource.ResourceType,
 		Tags:         baseResource.Tags,
 
-		HourlyCost:  diffDecimals(current.HourlyCost, past.HourlyCost),
-		MonthlyCost: diffDecimals(current.MonthlyCost, past.MonthlyCost),
+		HourlyCost:       diffDecimals(current.HourlyCost, past.HourlyCost),
+		MonthlyCost:      diffDecimals(current.MonthlyCost, past.MonthlyCost),
+		MonthlyEmissions: diffDecimals(current.MonthlyEmissions, past.MonthlyEmissions),
 	}
 	for _, subResource := range past.SubResources {
 		subKey := fmt.Sprintf("%v.%v", resourceKey, subResource.Name)
@@ -193,10 +194,12 @@ func diffCostComponents(past *CostComponent, current *CostComponent) (bool, *Cos
 		price:               *diffDecimals(&current.price, &past.price),
 		HourlyCost:          diffDecimals(current.HourlyCost, past.HourlyCost),
 		MonthlyCost:         diffDecimals(current.MonthlyCost, past.MonthlyCost),
+		MonthlyEmissions:    diffDecimals(current.MonthlyEmissions, past.MonthlyEmissions),
 	}
 	if !diff.HourlyQuantity.IsZero() || !diff.MonthlyQuantity.IsZero() ||
 		diff.MonthlyDiscountPerc != 0 || !diff.price.IsZero() ||
-		!diff.HourlyCost.IsZero() || !diff.MonthlyCost.IsZero() {
+		!diff.HourlyCost.IsZero() || !diff.MonthlyCost.IsZero() ||
+		!diff.MonthlyEmissions.IsZero() {
 		changed = true
 	}
 

--- a/internal/schema/resource.go
+++ b/internal/schema/resource.go
@@ -19,6 +19,7 @@ type Resource struct {
 	SubResources      []*Resource
 	HourlyCost        *decimal.Decimal
 	MonthlyCost       *decimal.Decimal
+	MonthlyEmissions  *decimal.Decimal
 	IsSkipped         bool
 	NoPrice           bool
 	SkipMessage       string
@@ -33,7 +34,25 @@ type Resource struct {
 func CalculateCosts(project *Project) {
 	for _, r := range project.AllResources() {
 		r.CalculateCosts()
+		r.CalculateEmittedCO2()
 	}
+}
+
+func (r *Resource) CalculateEmittedCO2() {
+	m := decimal.Zero
+	for _, c := range r.CostComponents {
+		c.CalculateEmittedCO2()
+		if c.MonthlyEmissions != nil {
+			m = m.Add(*c.MonthlyEmissions)
+		}
+	}
+	for _, s := range r.SubResources {
+		s.CalculateEmittedCO2()
+		if s.MonthlyEmissions != nil {
+			m = m.Add(*s.MonthlyEmissions)
+		}
+	}
+	r.MonthlyEmissions = &m
 }
 
 func (r *Resource) CalculateCosts() {


### PR DESCRIPTION
First version of the support for CO2e emissions by the Infracost CLI.
For now : 
- [x] Compatible only with table output
- [x] Limited testing for `infracost breakdown`
- ![photo_2022-10-28_09-28-25](https://user-images.githubusercontent.com/23173171/198529493-9f29cbdb-fce9-447e-b74c-e8e2facfcacd.jpg)


Roadmap : 
- [x] Add a parameter in the config to choose if we want to query & display emissions or not
- [x] Support `diff`
- [x] Support main output formats 
    - [x] `table` 
    - [x] `github`
    - [x] `html`


